### PR TITLE
fix(jar): enforce manifest digest and trust-anchor chain validation (CWE-347)

### DIFF
--- a/cmd/vsign/cli/verify/verify.go
+++ b/cmd/vsign/cli/verify/verify.go
@@ -102,7 +102,10 @@ func VerifyCmd(ctx context.Context, verifyOpts options.VerifyOptions, args []str
 		if opts.Compression != magic.CompressedNone {
 			return fmt.Errorf("cannot verify compressed file")
 		}
-		err = mod.Verify(f, verifyOpts, signers.VerifyOpts{Platform: connector, NoDigests: true})
+		// NoDigests is intentionally left false (the zero value) so that
+		// every file digest listed in MANIFEST.MF is validated against the
+		// actual JAR entry contents (CWE-347 fix).
+		err = mod.Verify(f, verifyOpts, signers.VerifyOpts{Platform: connector})
 		if err != nil {
 			return fmt.Errorf("verification error: %v", err.Error())
 		}

--- a/pkg/plugin/signers/jar/signer.go
+++ b/pkg/plugin/signers/jar/signer.go
@@ -20,6 +20,7 @@ package jar
 
 import (
 	"archive/zip"
+	"bytes"
 	"crypto/x509"
 	"fmt"
 	"io"
@@ -77,6 +78,14 @@ func sign(r io.Reader, certs []*x509.Certificate, opts signers.SignOpts) ([]byte
 	return opts.SetBinPatch(patch)
 }
 
+// verify checks the cryptographic integrity of a signed JAR file.
+//
+// Two security properties are enforced (CWE-347):
+//  1. Digest validation – every file entry listed in MANIFEST.MF is hashed
+//     and compared against its recorded digest (controlled by NoDigests in
+//     platformOpts; the caller must NOT set NoDigests: true for production use).
+//  2. Trust anchor validation – each PKCS#7 signature block is verified to
+//     chain up to a root CA that the Venafi platform considers authoritative.
 func verify(f *os.File, opts options.VerifyOptions, platformOpts signers.VerifyOpts) error {
 	experimental := figure.NewFigure("experimental: Jar signing", "", true)
 	experimental.Print()
@@ -89,9 +98,66 @@ func verify(f *os.File, opts options.VerifyOptions, platformOpts signers.VerifyO
 	if err != nil {
 		return err
 	}
-	_, err = jar.Verify(inz, platformOpts.NoDigests)
+
+	// Verify manifest digests and parse the embedded PKCS#7 signature blocks.
+	// platformOpts.NoDigests must be false (the default) for full integrity
+	// checking; a true value skips per-entry hash validation (CWE-347).
+	sigs, err := jar.Verify(inz, platformOpts.NoDigests)
 	if err != nil {
 		return err
+	}
+
+	if len(sigs) == 0 {
+		return fmt.Errorf("JAR contains no valid signatures")
+	}
+
+	// --- Trust anchor validation (CWE-347) ---
+	//
+	// Retrieve the certificate chain associated with the signing environment
+	// from the Venafi platform.  The chain is used to build an authoritative
+	// trust pool so that we can confirm each JAR signature was made by a key
+	// whose certificate chains to a known, trusted root CA.
+	env, err := platformOpts.Platform.GetEnvironment()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve platform environment for trust anchor validation: %w", err)
+	}
+
+	if len(env.CertificateChainData) == 0 {
+		return fmt.Errorf("platform returned an empty certificate chain; cannot perform trust anchor validation")
+	}
+
+	// Partition the chain into root CAs (trust anchors) and intermediates.
+	// A certificate is a root CA when its Subject and Issuer raw bytes are
+	// identical (self-signed).
+	trustedPool := x509.NewCertPool()
+	var intermediates []*x509.Certificate
+	rootFound := false
+
+	for _, derBytes := range env.CertificateChainData {
+		cert, parseErr := x509.ParseCertificate(derBytes)
+		if parseErr != nil {
+			return fmt.Errorf("failed to parse certificate from platform chain: %w", parseErr)
+		}
+		if bytes.Equal(cert.RawIssuer, cert.RawSubject) {
+			// Self-signed → root CA → trust anchor
+			trustedPool.AddCert(cert)
+			rootFound = true
+		} else {
+			intermediates = append(intermediates, cert)
+		}
+	}
+
+	if !rootFound {
+		return fmt.Errorf("no self-signed root CA found in platform certificate chain; cannot establish trust anchor")
+	}
+
+	// Validate the full X.509 chain for every signature found in the JAR.
+	// This rejects JARs signed by keys that do not chain to a trusted root,
+	// closing the CWE-347 trust-anchor gap.
+	for i, sig := range sigs {
+		if err := sig.TimestampedSignature.VerifyChain(trustedPool, intermediates, x509.ExtKeyUsageCodeSigning); err != nil {
+			return fmt.Errorf("JAR signature %d failed trust chain validation: %w", i+1, err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Closes two distinct CWE-347 (Improper Verification of Cryptographic Signature) gaps in JAR signature verification, as identified in finding `jar-CWE-347-no-trust-no-digests` (VC-53601 / VC-53597).

---

## Vulnerabilities fixed

### 1 — Digest validation was completely bypassed

**File:** `cmd/vsign/cli/verify/verify.go`

`mod.Verify` was called with `NoDigests: true` hardcoded:

```go
// BEFORE (vulnerable)
err = mod.Verify(f, verifyOpts, signers.VerifyOpts{Platform: connector, NoDigests: true})
```

This flag is forwarded to `pkg/provider/jar/verify.go`'s `Verify()`, which gates the entire `verifyManifest()` call behind `if !skipDigests`. With the flag always `true`, **no per-entry file digest in `MANIFEST.MF` was ever checked against actual JAR content**. An attacker could replace any `.class` or resource file in a signed JAR without triggering a verification error.

**Fix:** Remove `NoDigests: true` so the field defaults to `false`, restoring full per-entry manifest digest validation.

```go
// AFTER (fixed)
// NoDigests is intentionally left false (the zero value) so that
// every file digest listed in MANIFEST.MF is validated against the
// actual JAR entry contents (CWE-347 fix).
err = mod.Verify(f, verifyOpts, signers.VerifyOpts{Platform: connector})
```

---

### 2 — Trust anchor validation was absent

**File:** `pkg/plugin/signers/jar/signer.go`

The `verify()` function discarded the `[]*JarSignature` return value and never called `VerifyChain()`:

```go
// BEFORE (vulnerable)
_, err = jar.Verify(inz, platformOpts.NoDigests)
```

`pkcs7.Signature.Verify()` (called inside `jar.Verify`) only confirms the cryptographic signature matches the certificate **embedded in the signature block**. It does **not** verify that the certificate chains to a trusted root CA. Any attacker who generated a self-signed certificate and used it to sign a JAR would produce a signature that passed verification.

**Fix:** After `jar.Verify()` returns the parsed signatures, the code now:

1. Calls `platformOpts.Platform.GetEnvironment()` to retrieve the Venafi platform's authoritative certificate chain (DER-encoded).
2. Partitions the chain: self-signed certificates (`RawIssuer == RawSubject`) become trust anchors in an `x509.CertPool`; all other certificates become intermediates.
3. Returns an error if no root CA is found in the chain.
4. Calls `sig.TimestampedSignature.VerifyChain(trustedPool, intermediates, x509.ExtKeyUsageCodeSigning)` for every signature in the JAR, rejecting any that does not chain to a trusted root.

```go
// AFTER (fixed) — key additions
sigs, err := jar.Verify(inz, platformOpts.NoDigests)
// ...
trustedPool := x509.NewCertPool()
var intermediates []*x509.Certificate
for _, derBytes := range env.CertificateChainData {
    cert, _ := x509.ParseCertificate(derBytes)
    if bytes.Equal(cert.RawIssuer, cert.RawSubject) {
        trustedPool.AddCert(cert)   // root CA → trust anchor
    } else {
        intermediates = append(intermediates, cert)
    }
}
for i, sig := range sigs {
    if err := sig.TimestampedSignature.VerifyChain(
        trustedPool, intermediates, x509.ExtKeyUsageCodeSigning,
    ); err != nil {
        return fmt.Errorf("JAR signature %d failed trust chain validation: %w", i+1, err)
    }
}
```

---

## Files changed

| File | Change |
|------|--------|
| `cmd/vsign/cli/verify/verify.go` | Remove hardcoded `NoDigests: true` |
| `pkg/plugin/signers/jar/signer.go` | Capture signatures; add trust-pool construction and `VerifyChain` loop; import `"bytes"` |

## Testing

- `go build ./...` — clean ✅
- `go vet ./pkg/plugin/signers/jar/... ./cmd/vsign/cli/verify/...` — clean ✅
- Integration tests require a live Venafi TPP environment; the existing `sign_verify_test.go` test suite covers the sign→verify round-trip and should be run against a configured environment to validate the trust-chain path end-to-end.
