### PR TITLE
security: CWE-345: Remove signer-supplied trust root in PDF verification — VC-53787

### DIFF
--- a/pkg/provider/pdfsig/verify/verify.go
+++ b/pkg/provider/pdfsig/verify/verify.go
@@ -207,18 +207,13 @@ func Reader(file io.ReaderAt, size int64) (apiResp *Response, err error) {
 		}
 
 		// Verify the digital signature of the pdf file.
-		err = p7.VerifyWithChain(certPool)
-		if err != nil {
-			err = p7.Verify()
-			if err == nil {
-				signer.ValidSignature = true
-				signer.TrustedIssuer = false
-			} else {
-				apiResp.Error = fmt.Sprintln("Failed to verify signature:", err)
-			}
-		} else {
+		// Do not use signer-supplied certificates as trust root (CWE-345)
+		err = p7.Verify()
+		if err == nil {
 			signer.ValidSignature = true
-			signer.TrustedIssuer = true
+			signer.TrustedIssuer = false
+		} else {
+			apiResp.Error = fmt.Sprintln("Failed to verify signature:", err)
 		}
 
 		// PDF signature certificate revocation information attribute (1.2.840.113583.1.1.8)


### PR DESCRIPTION
## Summary

This PR fixes a CWE-345 (Insufficient Verification of Data Authenticity) vulnerability in PDF signature verification. The code was incorrectly using signer-supplied certificates as the trust root, allowing an attacker to sign a document with their own certificate and have it be trusted.

## Finding

**Vulnerability**: PDF signature verification uses signer-supplied certificate as trust root
**CWE**: CWE-345  
**Severity**: High
**Location**: `pkg/provider/pdfsig/verify/verify.go`

The vulnerable code created a certificate pool from the signer-supplied certificates in the PDF and passed it to `VerifyWithChain()` as the trust root. This means any certificate included by the signer would be trusted, completely bypassing certificate chain validation.

## Remediation

Removed the use of signer-supplied certificates as the trust root in PDF signature verification. The fix:

1. Removes the call to `p7.VerifyWithChain(certPool)` which used signer-supplied certificates as trusted roots
2. Only calls `p7.Verify()` which validates the signature cryptographically without trusting the signer's certificate chain
3. Sets `TrustedIssuer` to `false` since we cannot verify trust without a proper external trust store

The signer-supplied certificates are still used as intermediates for other certificate chain building operations, which is the correct usage.

## Verification

- **Build**: Passes (Go 1.25.7)
- **Tests**: Pre-existing test failures unrelated to this change (verified by running tests before and after the fix)
- **Impact**: The signature is still validated cryptographically, but `TrustedIssuer` will now correctly be set to `false` instead of incorrectly trusting self-supplied certificates

This is a minimal, focused fix that addresses the CWE-345 vulnerability without refactoring or breaking other functionality.