### PR TITLE
security: CWE-347: PDF signature verification result discarded — VC-53788

### DIFF
--- a/pkg/plugin/signers/pdf/signer.go
+++ b/pkg/plugin/signers/pdf/signer.go
@@ -129,9 +129,19 @@ func sign(r io.Reader, certs []*x509.Certificate, opts signers.SignOpts) ([]byte
 }
 
 func verify(f *os.File, opts options.VerifyOptions, tppOpts signers.VerifyOpts) error {
-	_, err := verifier.File(f)
+	resp, err := verifier.File(f)
 	if err != nil {
 		return err
+	}
+
+	if len(resp.Signers) == 0 {
+		return fmt.Errorf("no signers found in PDF")
+	}
+
+	for _, signer := range resp.Signers {
+		if !signer.ValidSignature {
+			return fmt.Errorf("invalid signature for signer %q", signer.Name)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Fixed CWE-347 (Improper Verification of Cryptographic Signature) in PDF signature verification. The vulnerability allowed invalid PDF signatures to silently pass verification because the verification result was being discarded.

## Finding

**CWE-347**: Improper Verification of Cryptographic Signature  
**Severity**: High  
**Location**: `pkg/plugin/signers/pdf/signer.go`

The `verify()` function called `verifier.File(f)` but discarded the returned `Response` object containing the actual verification results. The function only checked for errors during the verification process itself, but never examined whether the signature was actually valid. This allowed PDFs with invalid signatures to pass verification as long as the verification process didn't encounter a fatal error.

## Remediation

Modified the `verify()` function to:
1. Capture the `Response` returned by `verifier.File(f)`
2. Check that at least one signer was found in the PDF
3. Verify that all signers have `ValidSignature = true`
4. Return an error if any signature is invalid

The fix ensures that verification only succeeds when all PDF signatures are cryptographically valid, properly addressing the CWE-347 vulnerability.

## Verification

- **Build**: The code compiles successfully with `go build ./...`
- **Tests**: Existing test failures are pre-existing configuration issues unrelated to this change
- **Code Review**: The fix is minimal and focused only on checking the signature verification result