### PR TITLE
security: CWE-532: Remove trace logging of TPP authentication secrets — VC-53789

### DIFF
--- a/cmd/vsign/cli/getcred/getcred.go
+++ b/cmd/vsign/cli/getcred/getcred.go
@@ -72,7 +72,7 @@ func GetCredCmd(ctx context.Context, credOpts options.GetCredOptions, args []str
 			Scope:    endpoint.DefaultScope,
 			ClientId: endpoint.DefaultClientID}
 
-		resp, err := connector.GetCredential(auth)
+		_, err := connector.GetCredential(auth)
 		if err != nil {
 			return fmt.Errorf("error fetching token: %s", err)
 		}

--- a/cmd/vsign/cli/getcred/getcred.go
+++ b/cmd/vsign/cli/getcred/getcred.go
@@ -77,7 +77,7 @@ func GetCredCmd(ctx context.Context, credOpts options.GetCredOptions, args []str
 			return fmt.Errorf("error fetching token: %s", err)
 		}
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, NoColor: true})
-		log.Trace().Msgf("access_token: %s", resp)
+		// Trace logging disabled to prevent disclosure of access token (CWE-532)
 		//println("access_token: " + resp)
 	} else {
 		return fmt.Errorf("missing tpp credentials")

--- a/pkg/venafi/cloud/cloud.go
+++ b/pkg/venafi/cloud/cloud.go
@@ -120,7 +120,6 @@ func (c *Connector) request(method string, resource urlResource, data interface{
 	r, _ := http.NewRequest(method, url, payload)
 	r.Close = true
 	if c.accessToken != "" {
-		log.Trace().Msgf("Adding access token to request header for %s %s\n", method, url)
 		r.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.accessToken))
 	} else if c.apiKey != "" {
 		r.Header.Add(util.HeaderTpplApikey, c.apiKey)
@@ -141,16 +140,8 @@ func (c *Connector) request(method string, resource urlResource, data interface{
 	body, err = io.ReadAll(res.Body)
 
 	//
-	// Limit trace level logging in production as sensitive information may be disclosed
+	// Trace logging disabled to prevent disclosure of sensitive authentication data (CWE-532)
 	//
-
-	log.Trace().Msgf("Headers are:\n%s", r.Header)
-	if method == "POST" || method == "PUT" {
-		log.Trace().Msgf("JSON sent for %s\n%s\n", url, string(b))
-	} else {
-		log.Trace().Msgf("%s request sent to %s\n", method, url)
-	}
-	log.Trace().Msgf("Response:\n%s\n", string(body))
 
 	log.Trace().Msgf("Got %s status for %s %s\n", statusText, method, url)
 
@@ -163,7 +154,7 @@ func (c *Connector) requestURLEncoded(method string, resource urlResource, jwt s
 	formData := url.Values{}
 	formData.Set("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
 	formData.Set("assertion", jwt)
-	log.Trace().Msgf("Form data for %s:\n%s\n", apiUrl, formData.Encode())
+	// Trace logging disabled to prevent disclosure of JWT assertion (CWE-532)
 
 	res, err := c.getHTTPClient().PostForm(apiUrl, formData)
 	if err != nil {
@@ -180,15 +171,8 @@ func (c *Connector) requestURLEncoded(method string, resource urlResource, jwt s
 	body, err = io.ReadAll(res.Body)
 
 	//
-	// Limit trace level logging in production as sensitive information may be disclosed
+	// Trace logging disabled to prevent disclosure of sensitive authentication data (CWE-532)
 	//
-
-	if method == "POST" || method == "PUT" {
-		log.Trace().Msgf("JSON sent for %s\n%s\n", apiUrl, jwt)
-	} else {
-		log.Trace().Msgf("%s request sent to %s\n", method, apiUrl)
-	}
-	log.Trace().Msgf("Response:\n%s\n", string(body))
 
 	log.Trace().Msgf("Got %s status for %s %s\n", statusText, method, apiUrl)
 

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
-	"github.com/rs/zerolog/log"
 	"github.com/venafi/vsign/pkg/crypto"
 	"github.com/venafi/vsign/pkg/endpoint"
 	"github.com/venafi/vsign/pkg/util"

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -187,7 +187,7 @@ func (c *Connector) Authenticate(auth *endpoint.Authentication) (err error) {
 		resp := result.(OauthGetTokenResponse)
 		auth.AccessToken = resp.Access_token
 		c.accessToken = resp.Access_token
-		log.Trace().Msgf("Successfully authenticated with service account. Access token: %s", auth.AccessToken)
+		// Trace logging disabled to prevent disclosure of access token (CWE-532)
 		return nil
 	}
 

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -555,14 +555,14 @@ func processAuthData(c *Connector, url urlResource, data interface{}) (resp inte
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthGetRefreshTokenRequest/oauthGetAccessTokenFromJWTRequest response:\n%s\n", string(body))
+			// Trace logging disabled to prevent disclosure of tokens (CWE-532)
 			resp = getRefresh
 		case oauthRefreshAccessTokenRequest:
 			err = json.Unmarshal(body, &refreshAccess)
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthRefreshAccessTokenRequest response:\n%s\n", string(body))
+			// Trace logging disabled to prevent disclosure of tokens (CWE-532)
 			resp = refreshAccess
 		case authorizeRequest:
 			err = json.Unmarshal(body, &authorize)
@@ -575,7 +575,7 @@ func processAuthData(c *Connector, url urlResource, data interface{}) (resp inte
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthCertificateTokenRequest response:\n%s\n", string(body))
+			// Trace logging disabled to prevent disclosure of tokens (CWE-532)
 			resp = getRefresh
 		default:
 			return resp, fmt.Errorf("can not determine data type")

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -260,16 +260,8 @@ func (c *Connector) request(method string, resource urlResource, data interface{
 	body, err = io.ReadAll(res.Body)
 
 	//
-	// Limit trace level logging in production as sensitive information may be disclosed
+	// Trace logging disabled to prevent disclosure of sensitive authentication data (CWE-532)
 	//
-
-	log.Trace().Msgf("Headers are:\n%s", r.Header)
-	if method == "POST" || method == "PUT" {
-		log.Trace().Msgf("JSON sent for %s\n%s\n", url, string(b))
-	} else {
-		log.Trace().Msgf("%s request sent to %s\n", method, url)
-	}
-	log.Trace().Msgf("Response:\n%s\n", string(body))
 
 	log.Trace().Msgf("Got %s status for %s %s\n", statusText, method, url)
 


### PR DESCRIPTION
## Summary

Fixed CWE-532 (Insertion of Sensitive Information into Log File) by removing trace-level logging of TPP authentication secrets including access tokens, refresh tokens, JWT assertions, and request/response bodies containing credentials.

## Finding

**Repository:** venafi/vsign  
**Finding:** tpp-CWE-532-secrets-logged-at-trace  
**CWE:** CWE-532 - Insertion of Sensitive Information into Log File  
**Severity:** High

TPP authentication secrets (access tokens, refresh tokens, JWT assertions, passwords, and authentication request/response bodies) were being logged at trace level in multiple locations across the codebase. This could lead to credential disclosure in log files.

## Remediation

Removed trace logging statements that log sensitive authentication data:

1. **pkg/venafi/tpp/tpp.go** - Removed logging of HTTP headers, request bodies, and response bodies in the `request()` method
2. **pkg/venafi/tpp/connector.go** - Removed logging of OAuth token responses (refresh tokens, access tokens) in `processAuthData()`
3. **pkg/venafi/cloud/cloud.go** - Removed logging of HTTP headers, request bodies, response bodies, and JWT form data in `request()` and `requestURLEncoded()` methods
4. **pkg/venafi/cloud/connector.go** - Removed logging of access token in service account authentication
5. **cmd/vsign/cli/getcred/getcred.go** - Removed logging of access token in getcred command

All removals are minimal and focused only on preventing credential disclosure. Status code logging is retained for operational visibility.

## Verification

The changes remove only trace-level logging statements that expose authentication credentials. No functional code was modified. The remediation prevents CWE-532 violations while maintaining essential operational logging (HTTP status codes).

**Note:** Build/test failures in CI are due to Go toolchain environment configuration (`GOROOT directory not found`), not related to these code changes.