### PR TITLE
security: CWE-532: redact TPP auth secrets from trace logs — VC-53789

### DIFF
--- a/cmd/vsign/cli/getcred/getcred.go
+++ b/cmd/vsign/cli/getcred/getcred.go
@@ -77,7 +77,7 @@ func GetCredCmd(ctx context.Context, credOpts options.GetCredOptions, args []str
 			return fmt.Errorf("error fetching token: %s", err)
 		}
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, NoColor: true})
-		log.Trace().Msgf("access_token: %s", resp)
+		log.Trace().Msg("access_token retrieved successfully")
 		//println("access_token: " + resp)
 	} else {
 		return fmt.Errorf("missing tpp credentials")

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -555,14 +555,14 @@ func processAuthData(c *Connector, url urlResource, data interface{}) (resp inte
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthGetRefreshTokenRequest/oauthGetAccessTokenFromJWTRequest response:\n%s\n", string(body))
+			log.Trace().Msg("processAuthData oauthGetRefreshTokenRequest/oauthGetAccessTokenFromJWTRequest response received")
 			resp = getRefresh
 		case oauthRefreshAccessTokenRequest:
 			err = json.Unmarshal(body, &refreshAccess)
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthRefreshAccessTokenRequest response:\n%s\n", string(body))
+			log.Trace().Msg("processAuthData oauthRefreshAccessTokenRequest response received")
 			resp = refreshAccess
 		case authorizeRequest:
 			err = json.Unmarshal(body, &authorize)
@@ -575,7 +575,7 @@ func processAuthData(c *Connector, url urlResource, data interface{}) (resp inte
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthCertificateTokenRequest response:\n%s\n", string(body))
+			log.Trace().Msg("processAuthData oauthCertificateTokenRequest response received")
 			resp = getRefresh
 		default:
 			return resp, fmt.Errorf("can not determine data type")


### PR DESCRIPTION
## Summary

Remove TPP authentication secrets (OAuth response bodies, access tokens) from trace-level log statements to prevent credential exposure through log files.

## Finding

**CWE-532 — Information Exposure Through Log Files (High)**

Four trace-level log statements in the TPP authentication flow wrote sensitive material to logs:
- `pkg/venafi/tpp/connector.go` — three `log.Trace().Msgf()` calls dumped full OAuth response bodies (containing access tokens, refresh tokens) via `string(body)`
- `cmd/vsign/cli/getcred/getcred.go` — one `log.Trace().Msgf()` call logged the raw access token value

Even at trace level, these secrets can end up in log aggregators, crash dumps, or shared debug output.

## Remediation

Replaced each secret-logging statement with a confirmation-only message (e.g., `"response received"`, `"access_token retrieved successfully"`) that preserves debuggability without exposing credential material. No format-string arguments containing secrets remain.

**Files changed (2):**
- `pkg/venafi/tpp/connector.go` — 3 lines
- `cmd/vsign/cli/getcred/getcred.go` — 1 line

## Verification

- Build/test could not run due to pre-existing environment issue (missing GOROOT toolchain), not related to this change.
- Changes are purely log-message string edits (`Msgf` → `Msg` with no secret arguments) — no logic, control flow, or API surface is altered.