### PR TITLE
security: CWE-532: remove secrets from trace logs — VC-53789

### DIFF
--- a/cmd/vsign/cli/getcred/getcred.go
+++ b/cmd/vsign/cli/getcred/getcred.go
@@ -77,7 +77,7 @@ func GetCredCmd(ctx context.Context, credOpts options.GetCredOptions, args []str
 			return fmt.Errorf("error fetching token: %s", err)
 		}
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, NoColor: true})
-		log.Trace().Msgf("access_token: %s", resp)
+		log.Trace().Msg("access_token retrieved successfully")
 		//println("access_token: " + resp)
 	} else {
 		return fmt.Errorf("missing tpp credentials")

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -187,7 +187,7 @@ func (c *Connector) Authenticate(auth *endpoint.Authentication) (err error) {
 		resp := result.(OauthGetTokenResponse)
 		auth.AccessToken = resp.Access_token
 		c.accessToken = resp.Access_token
-		log.Trace().Msgf("Successfully authenticated with service account. Access token: %s", auth.AccessToken)
+		log.Trace().Msg("Successfully authenticated with service account")
 		return nil
 	}
 

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -555,14 +555,14 @@ func processAuthData(c *Connector, url urlResource, data interface{}) (resp inte
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthGetRefreshTokenRequest/oauthGetAccessTokenFromJWTRequest response:\n%s\n", string(body))
+			log.Trace().Msg("processAuthData oauthGetRefreshTokenRequest/oauthGetAccessTokenFromJWTRequest response received")
 			resp = getRefresh
 		case oauthRefreshAccessTokenRequest:
 			err = json.Unmarshal(body, &refreshAccess)
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthRefreshAccessTokenRequest response:\n%s\n", string(body))
+			log.Trace().Msg("processAuthData oauthRefreshAccessTokenRequest response received")
 			resp = refreshAccess
 		case authorizeRequest:
 			err = json.Unmarshal(body, &authorize)
@@ -575,7 +575,7 @@ func processAuthData(c *Connector, url urlResource, data interface{}) (resp inte
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthCertificateTokenRequest response:\n%s\n", string(body))
+			log.Trace().Msg("processAuthData oauthCertificateTokenRequest response received")
 			resp = getRefresh
 		default:
 			return resp, fmt.Errorf("can not determine data type")


### PR DESCRIPTION
## Summary

Remove authentication secrets (access tokens, OAuth response bodies) from trace-level log messages to prevent credential exposure through log files.

## Finding

CWE-532 (Information Exposure Through Log Files): TPP and cloud authentication secrets — including full OAuth response bodies containing access/refresh tokens — were written verbatim to trace-level log output in 5 locations across 3 files.

## Remediation

Replaced each `log.Trace().Msgf(...)` call that included secret values with a redacted variant that confirms the operation succeeded without emitting the sensitive data:

- `pkg/venafi/tpp/connector.go` (3 sites): OAuth response bodies (`string(body)`) removed from `processAuthData` trace logs.
- `pkg/venafi/cloud/connector.go` (1 site): Access token value removed from service-account authentication trace log.
- `cmd/vsign/cli/getcred/getcred.go` (1 site): Access token value removed from `getcred` trace log.

All log messages still confirm the operation occurred; only the secret payload is removed.

## Verification

- Build/test failures are pre-existing (Go toolchain not available in CI sandbox) and confirmed identical on unmodified code.
- Changes are log-message-only; no logic, control flow, or API surface is affected.