### PR TITLE
security: CWE-532: redact secrets from trace logs — VC-53789

### DIFF
--- a/cmd/vsign/cli/getcred/getcred.go
+++ b/cmd/vsign/cli/getcred/getcred.go
@@ -77,7 +77,7 @@ func GetCredCmd(ctx context.Context, credOpts options.GetCredOptions, args []str
 			return fmt.Errorf("error fetching token: %s", err)
 		}
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, NoColor: true})
-		log.Trace().Msgf("access_token: %s", resp)
+		log.Trace().Msg("access_token retrieved successfully")
 		//println("access_token: " + resp)
 	} else {
 		return fmt.Errorf("missing tpp credentials")

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -187,7 +187,7 @@ func (c *Connector) Authenticate(auth *endpoint.Authentication) (err error) {
 		resp := result.(OauthGetTokenResponse)
 		auth.AccessToken = resp.Access_token
 		c.accessToken = resp.Access_token
-		log.Trace().Msgf("Successfully authenticated with service account. Access token: %s", auth.AccessToken)
+		log.Trace().Msg("Successfully authenticated with service account")
 		return nil
 	}
 

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -555,14 +555,14 @@ func processAuthData(c *Connector, url urlResource, data interface{}) (resp inte
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthGetRefreshTokenRequest/oauthGetAccessTokenFromJWTRequest response:\n%s\n", string(body))
+			log.Trace().Msgf("processAuthData oauthGetRefreshTokenRequest/oauthGetAccessTokenFromJWTRequest response received (%d bytes)", len(body))
 			resp = getRefresh
 		case oauthRefreshAccessTokenRequest:
 			err = json.Unmarshal(body, &refreshAccess)
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthRefreshAccessTokenRequest response:\n%s\n", string(body))
+			log.Trace().Msgf("processAuthData oauthRefreshAccessTokenRequest response received (%d bytes)", len(body))
 			resp = refreshAccess
 		case authorizeRequest:
 			err = json.Unmarshal(body, &authorize)
@@ -575,7 +575,7 @@ func processAuthData(c *Connector, url urlResource, data interface{}) (resp inte
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthCertificateTokenRequest response:\n%s\n", string(body))
+			log.Trace().Msgf("processAuthData oauthCertificateTokenRequest response received (%d bytes)", len(body))
 			resp = getRefresh
 		default:
 			return resp, fmt.Errorf("can not determine data type")


### PR DESCRIPTION
## Summary

Remove authentication secrets (access tokens, OAuth response bodies) from trace-level log messages to prevent credential exposure through log files.

## Finding

CWE-532 — Information Exposure Through Log Files. Five trace-level log statements across three files logged plaintext authentication secrets:
- `pkg/venafi/tpp/connector.go`: Three calls logging full OAuth response bodies (containing access/refresh tokens) via `string(body)`
- `pkg/venafi/cloud/connector.go`: One call logging the plaintext access token after service-account authentication
- `cmd/vsign/cli/getcred/getcred.go`: One call logging the retrieved access token

## Remediation

- **TPP connector**: Replaced `string(body)` interpolation with byte-length indicator (`response received (N bytes)`), preserving diagnostic value without exposing token content.
- **Cloud connector**: Removed access token from success log message; now logs only that authentication succeeded.
- **getcred CLI**: Replaced token value log with a success confirmation message.

All changes are limited to log format strings — no behavioral, import, or type changes.

## Verification

- Build/test failures are pre-existing (missing local Go toolchain `golang.org/toolchain@v0.0.1-go1.25.8`), unrelated to these changes.
- Changes are string-only edits to `log.Trace()` calls; no functional code paths are affected.