### PR TITLE
security: CWE-532: redact secrets from trace logs — VC-53789

### DIFF
--- a/cmd/vsign/cli/getcred/getcred.go
+++ b/cmd/vsign/cli/getcred/getcred.go
@@ -77,7 +77,7 @@ func GetCredCmd(ctx context.Context, credOpts options.GetCredOptions, args []str
 			return fmt.Errorf("error fetching token: %s", err)
 		}
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, NoColor: true})
-		log.Trace().Msgf("access_token: %s", resp)
+		log.Trace().Msg("access_token retrieved successfully (value redacted)")
 		//println("access_token: " + resp)
 	} else {
 		return fmt.Errorf("missing tpp credentials")

--- a/pkg/venafi/cloud/connector.go
+++ b/pkg/venafi/cloud/connector.go
@@ -187,7 +187,7 @@ func (c *Connector) Authenticate(auth *endpoint.Authentication) (err error) {
 		resp := result.(OauthGetTokenResponse)
 		auth.AccessToken = resp.Access_token
 		c.accessToken = resp.Access_token
-		log.Trace().Msgf("Successfully authenticated with service account. Access token: %s", auth.AccessToken)
+		log.Trace().Msg("Successfully authenticated with service account (access token redacted)")
 		return nil
 	}
 

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -555,14 +555,14 @@ func processAuthData(c *Connector, url urlResource, data interface{}) (resp inte
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthGetRefreshTokenRequest/oauthGetAccessTokenFromJWTRequest response:\n%s\n", string(body))
+			log.Trace().Msgf("processAuthData oauthGetRefreshTokenRequest/oauthGetAccessTokenFromJWTRequest response received (body redacted)")
 			resp = getRefresh
 		case oauthRefreshAccessTokenRequest:
 			err = json.Unmarshal(body, &refreshAccess)
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthRefreshAccessTokenRequest response:\n%s\n", string(body))
+			log.Trace().Msgf("processAuthData oauthRefreshAccessTokenRequest response received (body redacted)")
 			resp = refreshAccess
 		case authorizeRequest:
 			err = json.Unmarshal(body, &authorize)
@@ -575,7 +575,7 @@ func processAuthData(c *Connector, url urlResource, data interface{}) (resp inte
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthCertificateTokenRequest response:\n%s\n", string(body))
+			log.Trace().Msgf("processAuthData oauthCertificateTokenRequest response received (body redacted)")
 			resp = getRefresh
 		default:
 			return resp, fmt.Errorf("can not determine data type")


### PR DESCRIPTION
## Summary

Redact authentication secrets (access tokens, OAuth response bodies) that were previously written verbatim to trace-level log output, mitigating CWE-532 (Insertion of Sensitive Information into Log File).

## Finding

TPP and Cloud authentication flows logged raw OAuth response bodies and access token values at trace level. If trace logging is enabled in production or logs are captured by a centralized logging system, these secrets could be exposed to unauthorized parties.

Affected locations:
- `pkg/venafi/tpp/connector.go` — three `log.Trace()` calls logging full `string(body)` of OAuth token responses
- `cmd/vsign/cli/getcred/getcred.go` — `log.Trace()` logging the access token value
- `pkg/venafi/cloud/connector.go` — `log.Trace()` logging the service-account access token

## Remediation

Replaced all secret-bearing log format strings with static messages that confirm the operation succeeded without emitting sensitive values. No signatures, imports, or control flow changed.

- `string(body)` → `"(body redacted)"`
- `access_token: %s` → `"access_token retrieved successfully (value redacted)"`
- `Access token: %s` → `"(access token redacted)"`

## Verification

- Build/test could not run due to missing Go toolchain in the CI environment (pre-existing, unrelated to this change).
- Changes are limited to log message strings only — no functional, type, or import modifications. No risk of behavioral regression.