### PR TITLE
security: CWE-532: redact TPP auth secrets from trace logs — VC-53789

### DIFF
--- a/cmd/vsign/cli/getcred/getcred.go
+++ b/cmd/vsign/cli/getcred/getcred.go
@@ -77,7 +77,7 @@ func GetCredCmd(ctx context.Context, credOpts options.GetCredOptions, args []str
 			return fmt.Errorf("error fetching token: %s", err)
 		}
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, NoColor: true})
-		log.Trace().Msgf("access_token: %s", resp)
+		log.Trace().Msg("access_token retrieved successfully")
 		//println("access_token: " + resp)
 	} else {
 		return fmt.Errorf("missing tpp credentials")

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -555,14 +555,14 @@ func processAuthData(c *Connector, url urlResource, data interface{}) (resp inte
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthGetRefreshTokenRequest/oauthGetAccessTokenFromJWTRequest response:\n%s\n", string(body))
+			log.Trace().Msgf("processAuthData oauthGetRefreshTokenRequest/oauthGetAccessTokenFromJWTRequest response received (%d bytes)", len(body))
 			resp = getRefresh
 		case oauthRefreshAccessTokenRequest:
 			err = json.Unmarshal(body, &refreshAccess)
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthRefreshAccessTokenRequest response:\n%s\n", string(body))
+			log.Trace().Msgf("processAuthData oauthRefreshAccessTokenRequest response received (%d bytes)", len(body))
 			resp = refreshAccess
 		case authorizeRequest:
 			err = json.Unmarshal(body, &authorize)
@@ -575,7 +575,7 @@ func processAuthData(c *Connector, url urlResource, data interface{}) (resp inte
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthCertificateTokenRequest response:\n%s\n", string(body))
+			log.Trace().Msgf("processAuthData oauthCertificateTokenRequest response received (%d bytes)", len(body))
 			resp = getRefresh
 		default:
 			return resp, fmt.Errorf("can not determine data type")
@@ -630,7 +630,7 @@ func GetPKSCertificate(url string) (*x509.Certificate, error) {
 		if err != nil {
 			return nil, err
 		}
-		log.Trace().Msgf("GetPKSCertificate response:\n%s\n", string(body))
+		log.Trace().Msgf("GetPKSCertificate response received (%d bytes)", len(body))
 		block, _ := pem.Decode(body)
 		cert, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -263,13 +263,13 @@ func (c *Connector) request(method string, resource urlResource, data interface{
 	// Limit trace level logging in production as sensitive information may be disclosed
 	//
 
-	log.Trace().Msgf("Headers are:\n%s", r.Header)
+	log.Trace().Msgf("Headers sent for %s (count: %d, auth present: %t)", url, len(r.Header), r.Header.Get("Authorization") != "")
 	if method == "POST" || method == "PUT" {
-		log.Trace().Msgf("JSON sent for %s\n%s\n", url, string(b))
+		log.Trace().Msgf("JSON sent for %s (%d bytes)\n", url, len(b))
 	} else {
 		log.Trace().Msgf("%s request sent to %s\n", method, url)
 	}
-	log.Trace().Msgf("Response:\n%s\n", string(body))
+	log.Trace().Msgf("Response for %s (%d bytes)\n", url, len(body))
 
 	log.Trace().Msgf("Got %s status for %s %s\n", statusText, method, url)
 


### PR DESCRIPTION
## Summary

Removes plaintext authentication secrets (access tokens, refresh tokens, OAuth response bodies, HTTP headers, request payloads) from trace-level log output in the TPP connector. Trace logging now emits only metadata (byte counts, URL, presence of auth header) instead of sensitive values.

## Finding

CWE-532 — Information Exposure Through Log Files. Multiple trace-level log statements in TPP authentication code wrote full OAuth token responses, HTTP Authorization headers, request/response bodies, and raw access tokens to logs.

## Remediation

- `pkg/venafi/tpp/tpp.go`: Replaced header dump with header count and auth-present boolean; replaced request/response body dumps with byte-length only.
- `pkg/venafi/tpp/connector.go`: Replaced four `string(body)` trace logs in `processAuthData` and `GetPKSCertificate` with byte-length messages.
- `cmd/vsign/cli/getcred/getcred.go`: Replaced direct access token logging with a success confirmation message.

All changes preserve trace-level diagnostic utility while eliminating secret exposure.

## Verification

- Build/test failure is pre-existing (missing Go toolchain `go1.25.8` in CI environment) — confirmed identical failure on clean `main` branch before changes.
- Changes are purely log-message string modifications; no logic, control flow, or API changes.