### PR TITLE
security: CWE-532: redact TPP auth secrets from trace logs — VC-53789

### DIFF
--- a/cmd/vsign/cli/getcred/getcred.go
+++ b/cmd/vsign/cli/getcred/getcred.go
@@ -72,7 +72,7 @@ func GetCredCmd(ctx context.Context, credOpts options.GetCredOptions, args []str
 			Scope:    endpoint.DefaultScope,
 			ClientId: endpoint.DefaultClientID}
 
-		resp, err := connector.GetCredential(auth)
+		_, err = connector.GetCredential(auth)
 		if err != nil {
 			return fmt.Errorf("error fetching token: %s", err)
 		}

--- a/cmd/vsign/cli/getcred/getcred.go
+++ b/cmd/vsign/cli/getcred/getcred.go
@@ -77,7 +77,7 @@ func GetCredCmd(ctx context.Context, credOpts options.GetCredOptions, args []str
 			return fmt.Errorf("error fetching token: %s", err)
 		}
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, NoColor: true})
-		log.Trace().Msgf("access_token: %s", resp)
+		log.Trace().Msg("access_token: [REDACTED]")
 		//println("access_token: " + resp)
 	} else {
 		return fmt.Errorf("missing tpp credentials")

--- a/pkg/venafi/tpp/connector.go
+++ b/pkg/venafi/tpp/connector.go
@@ -555,14 +555,14 @@ func processAuthData(c *Connector, url urlResource, data interface{}) (resp inte
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthGetRefreshTokenRequest/oauthGetAccessTokenFromJWTRequest response:\n%s\n", string(body))
+			log.Trace().Msgf("processAuthData oauthGetRefreshTokenRequest/oauthGetAccessTokenFromJWTRequest response: %d bytes", len(body))
 			resp = getRefresh
 		case oauthRefreshAccessTokenRequest:
 			err = json.Unmarshal(body, &refreshAccess)
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthRefreshAccessTokenRequest response:\n%s\n", string(body))
+			log.Trace().Msgf("processAuthData oauthRefreshAccessTokenRequest response: %d bytes", len(body))
 			resp = refreshAccess
 		case authorizeRequest:
 			err = json.Unmarshal(body, &authorize)
@@ -575,7 +575,7 @@ func processAuthData(c *Connector, url urlResource, data interface{}) (resp inte
 			if err != nil {
 				return resp, err
 			}
-			log.Trace().Msgf("processAuthData oauthCertificateTokenRequest response:\n%s\n", string(body))
+			log.Trace().Msgf("processAuthData oauthCertificateTokenRequest response: %d bytes", len(body))
 			resp = getRefresh
 		default:
 			return resp, fmt.Errorf("can not determine data type")

--- a/pkg/venafi/tpp/tpp.go
+++ b/pkg/venafi/tpp/tpp.go
@@ -263,13 +263,22 @@ func (c *Connector) request(method string, resource urlResource, data interface{
 	// Limit trace level logging in production as sensitive information may be disclosed
 	//
 
-	log.Trace().Msgf("Headers are:\n%s", r.Header)
+	sanitizedHeaders := make(http.Header)
+	for k, v := range r.Header {
+		switch http.CanonicalHeaderKey(k) {
+		case "Authorization", "X-Venafi-Api-Key":
+			sanitizedHeaders[k] = []string{"[REDACTED]"}
+		default:
+			sanitizedHeaders[k] = v
+		}
+	}
+	log.Trace().Msgf("Headers are:\n%s", sanitizedHeaders)
 	if method == "POST" || method == "PUT" {
-		log.Trace().Msgf("JSON sent for %s\n%s\n", url, string(b))
+		log.Trace().Msgf("JSON sent for %s: %d bytes\n", url, len(b))
 	} else {
 		log.Trace().Msgf("%s request sent to %s\n", method, url)
 	}
-	log.Trace().Msgf("Response:\n%s\n", string(body))
+	log.Trace().Msgf("Response for %s %s: %d bytes\n", method, url, len(body))
 
 	log.Trace().Msgf("Got %s status for %s %s\n", statusText, method, url)
 


### PR DESCRIPTION
## Summary

Trace-level logging in the TPP connector and credential commands was writing raw authentication secrets (access tokens, refresh tokens, OAuth response bodies, Authorization headers, and request payloads) to log output, violating CWE-532.

## Finding

CWE-532 — Insertion of Sensitive Information into Log File. TPP authentication secrets (access tokens, API keys, full OAuth response bodies containing tokens, Authorization headers, and JSON request bodies with credentials) were written verbatim to trace-level logs in three files.

## Remediation

- **`cmd/vsign/cli/getcred/getcred.go`**: Replaced raw access token logging with a `[REDACTED]` placeholder.
- **`pkg/venafi/tpp/connector.go`**: Replaced logging of full OAuth response bodies (which contain access/refresh tokens) with byte-length summaries in `processAuthData` for all three auth flows.
- **`pkg/venafi/tpp/tpp.go`**: In the generic `request()` function: sanitized `Authorization` and `X-Venafi-Api-Key` headers before logging; replaced raw request body logging with byte-length; replaced raw response body logging with byte-length.

## Verification

- Build and tests fail identically on unmodified `main` branch due to missing Go toolchain in CI environment (`GOROOT` not found) — not a regression from this change.
- Changes are minimal and confined to log format strings; no behavioral or API changes.