### PR TITLE
security: CWE-347: enforce JAR trust-anchor and digest verification — VC-53786

### DIFF
--- a/cmd/vsign/cli/verify/verify.go
+++ b/cmd/vsign/cli/verify/verify.go
@@ -102,7 +102,7 @@ func VerifyCmd(ctx context.Context, verifyOpts options.VerifyOptions, args []str
 		if opts.Compression != magic.CompressedNone {
 			return fmt.Errorf("cannot verify compressed file")
 		}
-		err = mod.Verify(f, verifyOpts, signers.VerifyOpts{Platform: connector, NoDigests: true})
+		err = mod.Verify(f, verifyOpts, signers.VerifyOpts{Platform: connector, NoDigests: false})
 		if err != nil {
 			return fmt.Errorf("verification error: %v", err.Error())
 		}

--- a/pkg/plugin/signers/jar/signer.go
+++ b/pkg/plugin/signers/jar/signer.go
@@ -89,9 +89,25 @@ func verify(f *os.File, opts options.VerifyOptions, platformOpts signers.VerifyO
 	if err != nil {
 		return err
 	}
-	_, err = jar.Verify(inz, platformOpts.NoDigests)
+	sigs, err := jar.Verify(inz, platformOpts.NoDigests)
 	if err != nil {
 		return err
+	}
+
+	// Validate certificate chain against trusted roots
+	if !platformOpts.NoChain {
+		roots := platformOpts.TrustedPool
+		if roots == nil {
+			roots, err = x509.SystemCertPool()
+			if err != nil {
+				return fmt.Errorf("failed to load system certificate pool: %w", err)
+			}
+		}
+		for _, sig := range sigs {
+			if err := sig.TimestampedSignature.VerifyChain(roots, platformOpts.TrustedX509, x509.ExtKeyUsageCodeSigning); err != nil {
+				return fmt.Errorf("certificate chain verification failed: %w", err)
+			}
+		}
 	}
 
 	return nil

--- a/pkg/provider/jar/verify.go
+++ b/pkg/provider/jar/verify.go
@@ -149,6 +149,15 @@ func verifyManifest(inz *zip.Reader, manifest []byte) error {
 			return err
 		}
 	}
+	// Reject JAR files that contain unsigned content outside META-INF/
+	for name := range zipfiles {
+		if strings.HasPrefix(name, "META-INF/") || strings.HasSuffix(name, "/") {
+			continue
+		}
+		if parsed.Files[name] == nil {
+			return fmt.Errorf("file \"%s\" is in the JAR but not covered by MANIFEST.MF", name)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

JAR signature verification was incomplete: digest verification was always skipped via a hardcoded flag, certificate chain validation was never performed, and unsigned files in a JAR were not detected.

## Finding

**CWE-347 — Improper Verification of Cryptographic Signature**  
Finding ID: `jar-CWE-347-no-trust-no-digests`

Three gaps in `jar.Verify` and its callers:
1. `NoDigests: true` hardcoded in the verify command, unconditionally skipping manifest digest checks.
2. Returned `JarSignature` objects were discarded (`_`), so `VerifyChain()` was never called — no trust-anchor validation.
3. `verifyManifest` only checked files listed in the manifest, not whether all JAR entries were covered — allowing unsigned file injection.

## Remediation

1. **`cmd/vsign/cli/verify/verify.go`**: Changed `NoDigests: true` → `NoDigests: false` so file digests in `MANIFEST.MF` are verified against actual JAR contents.
2. **`pkg/plugin/signers/jar/signer.go`**: Capture returned signatures and call `TimestampedSignature.VerifyChain()` against the provided `TrustedPool` (or system cert pool as fallback) unless `NoChain` is set.
3. **`pkg/provider/jar/verify.go`**: Added a check in `verifyManifest` that every non-META-INF, non-directory file in the JAR has a corresponding entry in `MANIFEST.MF`.

## Verification

- Build and tests could not run due to a pre-existing Go toolchain mismatch in the CI environment (requires go ≥ 1.25.7, only 1.23.8 available).
- Changes are minimal and limited to the three files identified. No API changes to exported functions.
- `jar.Verify` already returned `[]*JarSignature`; the fix uses the existing return value.
- `crypto/x509` was already imported in `signer.go`; `strings` was already imported in `verify.go`. No new dependencies.