### PR TITLE
security: CWE-347: check PDF signature verification result — VC-53788

### DIFF
--- a/pkg/plugin/signers/pdf/signer.go
+++ b/pkg/plugin/signers/pdf/signer.go
@@ -129,9 +129,23 @@ func sign(r io.Reader, certs []*x509.Certificate, opts signers.SignOpts) ([]byte
 }
 
 func verify(f *os.File, opts options.VerifyOptions, tppOpts signers.VerifyOpts) error {
-	_, err := verifier.File(f)
+	resp, err := verifier.File(f)
 	if err != nil {
 		return err
+	}
+
+	if resp.Error != "" {
+		return fmt.Errorf("pdf signature verification failed: %s", resp.Error)
+	}
+
+	if len(resp.Signers) == 0 {
+		return fmt.Errorf("pdf contains no signers")
+	}
+
+	for _, signer := range resp.Signers {
+		if !signer.ValidSignature {
+			return fmt.Errorf("pdf signature is not valid for signer %q", signer.Name)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

The `verify()` function in the PDF signer plugin discarded the `*Response` returned by `verifier.File()`, only checking the `error` return. Since `verifier.File()` records signature validation failures in `Response.Error` and `Signer.ValidSignature` fields (returning `nil` error), invalid PDF signatures silently passed verification.

## Finding

**CWE-347 — Improper Verification of Cryptographic Signature**

`pkg/plugin/signers/pdf/signer.go` — the `verify` function assigned the `*verify.Response` to `_`, ignoring the `ValidSignature` flag and `Error` string that indicate verification failures. An attacker-supplied PDF with a tampered or invalid signature would pass verification without error.

## Remediation

The fix inspects the returned `*Response` for three failure conditions:
1. `resp.Error` is non-empty — propagates the error string
2. `resp.Signers` is empty — returns an error (no signers found)
3. Any signer has `ValidSignature == false` — returns an error naming the signer

Only `pkg/plugin/signers/pdf/signer.go` was modified (single file, 15 lines added).

## Verification

- The changed package builds successfully (`go build ./pkg/plugin/signers/pdf/`)
- Build/test infrastructure failures are pre-existing (Go toolchain misconfiguration on the CI host), unrelated to this change